### PR TITLE
Introduce multiple features to cycle time model

### DIFF
--- a/feature-or-not.py
+++ b/feature-or-not.py
@@ -15,22 +15,79 @@ tf.logging.set_verbosity(tf.logging.ERROR)
 pd.options.display.max_rows = 10
 pd.options.display.float_format = '{:.1f}'.format
 
+# Set up and preprocess dataset
 pull_requests_dataframe = pd.read_csv("/pull_requests.csv")
 
 pull_requests_dataframe = pull_requests_dataframe.reindex(
         np.random.permutation(pull_requests_dataframe.index))
 
+pull_requests_dataframe["body_char_count"] = (
+    pull_requests_dataframe["body"].str.len())
+
+relevant_features = ['additions_count', 'deletions_count', 'changed_files_count', 'body_char_count', 'time_to_review_in_minutes']
+
 # Filter out rows where relevant features are null
-pull_requests_dataframe = pull_requests_dataframe.dropna(subset=['size', 'cycle_time_in_days'])
+pull_requests_dataframe = pull_requests_dataframe.dropna(subset=(['cycle_time_in_days'] + relevant_features))
+
+# Trim outliers
+pull_requests_dataframe["additions_count"] = (
+    pull_requests_dataframe["additions_count"].apply(lambda x: min(x, 10000)))
+
+pull_requests_dataframe["deletions_count"] = (
+    pull_requests_dataframe["deletions_count"].apply(lambda x: min(x, 10000)))
+
+pull_requests_dataframe["changed_files_count"] = (
+    pull_requests_dataframe["changed_files_count"].apply(lambda x: min(x, 300)))
+
+pull_requests_dataframe["time_to_review_in_minutes"] = (
+    pull_requests_dataframe["time_to_review_in_minutes"].apply(lambda x: min(x, 1000)))
+
+# There is a huge amount of variability here - cap at 5 days
+pull_requests_dataframe["cycle_time_in_days"] = (
+    pull_requests_dataframe["cycle_time_in_days"].apply(lambda x: min(x, 5)))
+
+print(pull_requests_dataframe.describe())
 
 """
-To get started with ML, first predict one label from one feature
-We will predict time-to-review based on the size of the PR
+We will first predict time-to-review based on the size of the PR
 
 See: https://developers.google.com/machine-learning/crash-course/first-steps-with-tensorflow/programming-exercises
 """
+
+def preprocess_features(pull_requests_dataframe):
+  """Prepares input features from California housing data set.
+
+  Args:
+    pull_requests_dataframe: A Pandas DataFrame expected to contain data
+      from the California housing data set.
+  Returns:
+    A DataFrame that contains the features to be used for the model, including
+    synthetic features.
+  """
+  selected_features = pull_requests_dataframe[
+      relevant_features
+    ]
+  processed_features = selected_features.copy()
+
+  return processed_features
+
+def preprocess_targets(pull_requests_dataframe):
+  """Prepares target features (i.e., labels) from California housing data set.
+
+  Args:
+    pull_requests_dataframe: A Pandas DataFrame expected to contain data
+      from the California housing data set.
+  Returns:
+    A DataFrame that contains the target feature.
+  """
+  output_targets = pd.DataFrame()
+  # Scale the target to be in minutes
+  output_targets["cycle_time_in_minutes"] = (
+      pull_requests_dataframe["cycle_time_in_days"] * 24 * 60)
+  return output_targets
+
 def my_input_fn(features, targets, batch_size=1, shuffle=True, num_epochs=None):
-    """Trains a linear regression model of one feature.
+    """Trains a linear regression model of multiple features.
   
     Args:
       features: pandas DataFrame of features
@@ -51,65 +108,86 @@ def my_input_fn(features, targets, batch_size=1, shuffle=True, num_epochs=None):
     
     # Shuffle the data, if specified.
     if shuffle:
-      ds = ds.shuffle(buffer_size=10000)
+      ds = ds.shuffle(10000)
     
     # Return the next batch of data.
     features, labels = ds.make_one_shot_iterator().get_next()
     return features, labels
 
-def train_model(learning_rate, steps, batch_size, input_feature):
-  """Trains a linear regression model.
+def construct_feature_columns(input_features):
+  """Construct the TensorFlow Feature Columns.
+
+  Args:
+    input_features: The names of the numerical input features to use.
+  Returns:
+    A set of feature columns
+  """ 
+  return set([tf.feature_column.numeric_column(my_feature)
+              for my_feature in input_features])
+
+def train_model(
+    learning_rate,
+    steps,
+    batch_size,
+    training_examples,
+    training_targets,
+    validation_examples,
+    validation_targets):
+  """Trains a linear regression model of multiple features.
+  
+  In addition to training, this function also prints training progress information,
+  as well as a plot of the training and validation loss over time.
   
   Args:
     learning_rate: A `float`, the learning rate.
     steps: A non-zero `int`, the total number of training steps. A training step
       consists of a forward and backward pass using a single batch.
     batch_size: A non-zero `int`, the batch size.
-    input_feature: A `string` specifying a column from `pull_requests_dataframe`
-      to use as input feature.
+    training_examples: A `DataFrame` containing one or more columns from
+      `california_housing_dataframe` to use as input features for training.
+    training_targets: A `DataFrame` containing exactly one column from
+      `california_housing_dataframe` to use as target for training.
+    validation_examples: A `DataFrame` containing one or more columns from
+      `california_housing_dataframe` to use as input features for validation.
+    validation_targets: A `DataFrame` containing exactly one column from
+      `california_housing_dataframe` to use as target for validation.
       
   Returns:
-    A Pandas `DataFrame` containing targets and the corresponding predictions done
-    after training the model.
+    A `LinearRegressor` object trained on the training data.
   """
-  
+
   periods = 10
   steps_per_period = steps / periods
-
-  my_feature = input_feature
-  my_feature_data = pull_requests_dataframe[[my_feature]].astype('float32')
-  my_label = "cycle_time_in_minutes"
-  targets = pull_requests_dataframe[my_label].astype('float32')
-
-  # Create input functions.
-  training_input_fn = lambda: my_input_fn(my_feature_data, targets, batch_size=batch_size)
-  predict_training_input_fn = lambda: my_input_fn(my_feature_data, targets, num_epochs=1, shuffle=False)
   
-  # Create feature columns.
-  feature_columns = [tf.feature_column.numeric_column(my_feature)]
-    
   # Create a linear regressor object.
   my_optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate)
   my_optimizer = tf.contrib.estimator.clip_gradients_by_norm(my_optimizer, 5.0)
   linear_regressor = tf.estimator.LinearRegressor(
-      feature_columns=feature_columns,
+      feature_columns=construct_feature_columns(training_examples),
       optimizer=my_optimizer
   )
-
-  # Set up to plot the state model's line.
-  plt.figure(figsize=(15, 6))
-  plt.subplot(1, 2, 1)
-  plt.title("Learned Line")
-  plt.ylabel(my_label)
-  plt.xlabel(my_feature)
-  sample = pull_requests_dataframe.sample(n=500)
-  plt.scatter(sample[my_feature], sample[my_label])
+  
+  # Create input functions.
+  training_input_fn = lambda: my_input_fn(
+      training_examples, 
+      training_targets["cycle_time_in_minutes"], 
+      batch_size=batch_size)
+  predict_training_input_fn = lambda: my_input_fn(
+      training_examples, 
+      training_targets["cycle_time_in_minutes"], 
+      num_epochs=1, 
+      shuffle=False)
+  predict_validation_input_fn = lambda: my_input_fn(
+      validation_examples, validation_targets["cycle_time_in_minutes"], 
+      num_epochs=1, 
+      shuffle=False)
 
   # Train the model, but do so inside a loop so that we can periodically assess
   # loss metrics.
   print("Training model...")
   print("RMSE (on training data):")
-  root_mean_squared_errors = []
+  training_rmse = []
+  validation_rmse = []
   for period in range (0, periods):
     # Train the model, starting from the prior state.
     linear_regressor.train(
@@ -117,43 +195,31 @@ def train_model(learning_rate, steps, batch_size, input_feature):
         steps=steps_per_period,
     )
     # Take a break and compute predictions.
-    predictions = linear_regressor.predict(input_fn=predict_training_input_fn)
-    predictions = np.array([item['predictions'][0] for item in predictions])
+    training_predictions = linear_regressor.predict(input_fn=predict_training_input_fn)
+    training_predictions = np.array([item['predictions'][0] for item in training_predictions])
     
-    # Compute loss.
-    root_mean_squared_error = math.sqrt(
-      metrics.mean_squared_error(predictions, targets))
+    validation_predictions = linear_regressor.predict(input_fn=predict_validation_input_fn)
+    validation_predictions = np.array([item['predictions'][0] for item in validation_predictions])
+    
+    # Compute training and validation loss.
+    training_root_mean_squared_error = math.sqrt(
+        metrics.mean_squared_error(training_predictions, training_targets))
+    validation_root_mean_squared_error = math.sqrt(
+        metrics.mean_squared_error(validation_predictions, validation_targets))
     # Occasionally print the current loss.
-    print("  period %02d : %0.2f" % (period, root_mean_squared_error))
+    print("  period %02d : %0.2f" % (period, training_root_mean_squared_error))
     # Add the loss metrics from this period to our list.
-    root_mean_squared_errors.append(root_mean_squared_error)
-
+    training_rmse.append(training_root_mean_squared_error)
+    validation_rmse.append(validation_root_mean_squared_error)
   print("Model training finished.")
-
-  # Plot sampled data vs. prediction line
-  y_extents = np.array([0, sample[my_label].max()])
-
-  weight = linear_regressor.get_variable_value('linear/linear_model/%s/weights' % input_feature)[0]
-  bias = linear_regressor.get_variable_value('linear/linear_model/bias_weights')
-
-  x_extents = (y_extents - bias) / weight
-  x_extents = np.maximum(np.minimum(x_extents,
-    sample[my_feature].max()),
-    sample[my_feature].min())
-  y_extents = weight * x_extents + bias
-  plt.plot(x_extents, y_extents) 
 
   # Create a table with calibration data.
   calibration_data = pd.DataFrame()
-  calibration_data["predictions"] = pd.Series(predictions)
-  calibration_data["targets"] = pd.Series(targets)
+  calibration_data["predictions"] = pd.Series(training_predictions)
+  calibration_data["targets"] = pd.Series(training_targets["cycle_time_in_minutes"])
   print(calibration_data.describe())
 
-  print("Final RMSE (on training data): %0.2f" % root_mean_squared_error)
-  print([(v, linear_regressor.get_variable_value(v)) for v in linear_regressor.get_variable_names()])
-
   # Plot predicted vs. actual
-  plt.subplot(1, 2, 2)
   plt.title("Predictions vs. Actual")
   plt.xlabel("predicted_cycle_time_in_minutes")
   plt.ylabel("actual_cycle_time_in_minutes")
@@ -161,21 +227,31 @@ def train_model(learning_rate, steps, batch_size, input_feature):
   plt.savefig("/tmp/fig.png")
 
   # Output model bias + weights
-  print(linear_regressor.model_fn)
+  print([(v, linear_regressor.get_variable_value(v)) for v in linear_regressor.get_variable_names()])
 
-  return calibration_data
+  return linear_regressor
 
-pull_requests_dataframe["size"] = (
-    pull_requests_dataframe["size"]).apply(lambda x: min(x, 10000))
+"""
+End helper fns
+"""
+# Set up training + validation examples
+training_examples = preprocess_features(pull_requests_dataframe.head(2000))
+print(training_examples.describe())
 
-pull_requests_dataframe["cycle_time_in_days"] = (
-    pull_requests_dataframe["cycle_time_in_days"]).apply(lambda x: min(x, 20))
+training_targets = preprocess_targets(pull_requests_dataframe.head(2000))
+print(training_targets.describe())
 
-pull_requests_dataframe["cycle_time_in_minutes"] = (
-    pull_requests_dataframe["cycle_time_in_days"]).apply(lambda x: x * 24 * 60)
+validation_examples = preprocess_features(pull_requests_dataframe.tail(500))
+print(validation_examples.describe())
 
-calibration_data = train_model(
+validation_targets = preprocess_targets(pull_requests_dataframe.tail(500))
+print(validation_targets.describe())
+
+linear_regressor = train_model(
     learning_rate=0.00001,
     steps=5000,
     batch_size=200,
-    input_feature="size")
+    training_examples=training_examples,
+    training_targets=training_targets,
+    validation_examples=validation_examples,
+    validation_targets=validation_targets)


### PR DESCRIPTION
Mostly proof of concept, but this incorporates a set of features
(additions, deletions, files changed, size of PR body, and time to
review) to predict the cycle time.

It is definitely better than the single-feature model: the root mean
squared error has decreased from 2112 to 1781.

Also interesting to see the relative feature weights:
```
[('global_step', 5000),
('linear/linear_model/bias_weights', 
array([0.00040529],dtype=float32)),
('linear/linear_model/additions_count/weights',
array([[0.06855616]], dtype=float32)),
('linear/linear_model/body_char_count/weights',
array([[0.11293091]], dtype=float32)),
('linear/linear_model/changed_files_count/weights',
array([[0.00347315]], dtype=float32)),
('linear/linear_model/deletions_count/weights',
array([[0.02874885]], dtype=float32)),
('linear/linear_model/time_to_review_in_minutes/weights',
array([[0.20342691]], dtype=float32))]
```

![image](https://user-images.githubusercontent.com/6531644/47524098-b1bd3b80-d867-11e8-9bd8-c8c4cdc204ca.png)

Future ideas to improve:
- Bucketing
- Introduce neural network layers